### PR TITLE
Fix documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Requires a valid [golang](https://github.com/golang/go/wiki/Ubuntu) installation
 
 ```sh
 go get -u github.com/gobuffalo/packr/v2/packr2
+go get -u github.com/silvergasp/CubeMxToBazel
 packr2 install github.com/silvergasp/CubeMxToBazel
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Running the generator is as simple as changing directories into the project and 
 
 ```sh
 cd YOUR_PROJECT_PATH_HERE
+touch WORKSPACE
 $GOPATH/bin/CubeMxToBazel
 ```
 


### PR DESCRIPTION
I noticed that the `packr2` command fails during installation, if I did not fetch the _CubeMXToBazel_ repo first. Also for newly created project the _BUILD_ file creation fails, if there is no existing _WORKSPACE_ file. In case there is already an existing _WORKSPACE_ file, the `touch` command will not modify the existing file.

edit: formatting